### PR TITLE
 fix(scaffolding): compiling failed with semicolons

### DIFF
--- a/src/_scaffolding.sass
+++ b/src/_scaffolding.sass
@@ -165,7 +165,6 @@
   color: $text-color
   display: block
   font-size: 15px
-  padding: 8px 5px 4px
   width: 100%
   transition: border-color $animate-speed, color $animate-speed
 
@@ -343,7 +342,7 @@
     // Range
     &[type="range"]
       border: none
-      padding: 13px 0px
+      padding: 13px 0
       -webkit-appearance: none
       width: 100%
       cursor: pointer

--- a/src/_scaffolding.sass
+++ b/src/_scaffolding.sass
@@ -19,7 +19,7 @@
 
   p &
     text-decoration: underline
-    display: inline;
+    display: inline
 
 
 @if $frow-enable-html-basics == true
@@ -129,7 +129,7 @@
         &:focus,
         &:active
           color: lighten($link-color, 40%)
-          text-decoration: none;
+          text-decoration: none
 
     &.button-none
       &,
@@ -170,7 +170,7 @@
   transition: border-color $animate-speed, color $animate-speed
 
   &::placeholder
-    opacity: 1;
+    opacity: 1
     color: $form-placeholder-color
 
   &:placeholder-shown
@@ -180,7 +180,7 @@
     color: $form-placeholder-color
 
   &::-moz-placeholder
-    opacity: 1;
+    opacity: 1
     color: $form-placeholder-color
 
   &:-ms-input-placeholder


### PR DESCRIPTION
Hello, when I am using the new angular-cli(v8.0.1) to create a new project, import frow library then it shows me the error below. My sass version is 1.19.0 .
So I am trying to fix this. BTW, a code refactor commit too. Thanks for your time.
> ```
>          Semicolons aren't allowed in the indented syntax.
>       │
>  22   │     display: inline;
>       │                    ^
>       │
> ```